### PR TITLE
Small optimization in dynamic.py

### DIFF
--- a/src/genpy/dynamic.py
+++ b/src/genpy/dynamic.py
@@ -95,7 +95,10 @@ def _gen_dyn_modify_references(py_text, current_type, types):
         # - remove any import statements
         py_text = py_text.replace("import %s.msg"%pkg, '')
         # - rewrite any references to class
-        py_text = re.sub("(?<!\w)%s\.msg\.%s(?!\w)"%(pkg, base_type), gen_name, py_text)
+        if '.msg' in py_text:
+            # calling re.sub results in significant overhead. Search for '.msg' to skip
+            # the re.sub call when possible.
+            py_text = re.sub("(?<!\w)%s\.msg\.%s(?!\w)"%(pkg, base_type), gen_name, py_text)
 
     pkg, base_type = genmsg.package_resource_name(current_type)
     gen_name = _gen_dyn_name(pkg, base_type)


### PR DESCRIPTION
Calling `re.sub` results in significant overhead. Searching for `'.msg'` allows skipping the call when it is not needed.